### PR TITLE
feat: implement reserves data caching

### DIFF
--- a/.changeset/proud-beers-behave.md
+++ b/.changeset/proud-beers-behave.md
@@ -1,0 +1,5 @@
+---
+'@protocolink/lending': minor
+---
+
+implement reserves data caching

--- a/packages/lending/src/adapter.test.ts
+++ b/packages/lending/src/adapter.test.ts
@@ -2,8 +2,33 @@ import { Adapter } from 'src/adapter';
 import * as common from '@protocolink/common';
 import { expect } from 'chai';
 import { filterPortfolio } from './protocol.utils';
+import { supportedChainIds } from './adapter.config';
 
-describe('Test Adapter for getPortfolios', function () {
+describe('Test Adapter', function () {
+  context('Test getProtocolInfos', function () {
+    supportedChainIds.forEach((chainId) => {
+      it(`network: ${common.toNetworkId(chainId)}`, async function () {
+        const adapter = await Adapter.createAdapter(chainId);
+
+        const protocolInfos = await adapter.getProtocolInfos();
+
+        protocolInfos.forEach((protocolInfo) => {
+          expect(protocolInfo).has.property('chainId', chainId);
+          expect(protocolInfo).has.property('protocolId');
+          expect(protocolInfo).has.property('marketId');
+
+          expect(Array.isArray(protocolInfo.reserveTokens)).to.equal(true);
+
+          protocolInfo.reserveTokens.forEach((reserveToken) => {
+            expect(reserveToken).has.property('asset');
+            expect(reserveToken).has.property('isSupplyEnabled');
+            expect(reserveToken).has.property('isBorrowEnabled');
+          });
+        });
+      });
+    });
+  });
+
   context('Test getPortfolios', function () {
     const testCases = [
       {

--- a/packages/lending/src/adapter.test.ts
+++ b/packages/lending/src/adapter.test.ts
@@ -17,7 +17,7 @@ describe('Test Adapter', function () {
           expect(protocolInfo).has.property('protocolId');
           expect(protocolInfo).has.property('marketId');
 
-          expect(Array.isArray(protocolInfo.reserveTokens)).to.equal(true);
+          expect(protocolInfo.reserveTokens).to.have.lengthOf.above(0);
 
           protocolInfo.reserveTokens.forEach((reserveToken) => {
             expect(reserveToken).has.property('asset');

--- a/packages/lending/src/adapter.ts
+++ b/packages/lending/src/adapter.ts
@@ -8,12 +8,12 @@ import {
 } from './adapter.type';
 import { Portfolio } from './protocol.portfolio';
 import { Protocol, ProtocolClass } from './protocol';
+import { ProtocolInfo, defaultSlippage } from './protocol.type';
 import { Swapper, SwapperClass } from './swapper';
 import { SwapperQuoteFields } from './swapper.type';
 import * as apisdk from '@protocolink/api';
 import * as common from '@protocolink/common';
 import { configMap } from './adapter.config';
-import { defaultSlippage } from './protocol.type';
 import flatten from 'lodash/flatten';
 import { providers } from 'ethers';
 import { scaleRepayAmount } from './adapter.utils';
@@ -205,12 +205,25 @@ export class Adapter extends common.Web3Toolkit {
   }
 
   /**
+   * Retrieves an array of protocol information (tokens) from all registered protocols.
+   *
+   * @returns {Promise<ProtocolInfo[]>} an array of protocol information (tokens)
+   */
+  async getProtocolInfos(): Promise<ProtocolInfo[]> {
+    const protocolInfos = await Promise.all(
+      Object.values(this.protocolMap).map(async (protocol) => {
+        return await protocol.getProtocolInfos();
+      })
+    );
+    return flatten(protocolInfos);
+  }
+
+  /**
    * Retrieves a protocol instance by its identifier.
    *
    * @param {string} id - The identifier of the protocol.
    * @returns {Protocol} The Protocol instance associated with the given identifier.
    */
-
   getProtocol(id: string): Protocol {
     return this.protocolMap[id];
   }

--- a/packages/lending/src/protocol.ts
+++ b/packages/lending/src/protocol.ts
@@ -2,6 +2,7 @@ import {
   BorrowFields,
   BorrowParams,
   Market,
+  ProtocolInfo,
   RepayFields,
   RepayParams,
   SupplyFields,
@@ -39,6 +40,8 @@ export abstract class Protocol extends common.Web3Toolkit {
   abstract getPortfolio(account: string, marketId: string): Promise<Portfolio>;
 
   abstract getPortfolios(account: string): Promise<Portfolio[]>;
+
+  abstract getProtocolInfos(): Promise<ProtocolInfo[]>;
 
   async getLstTokenAPYMap(chainId: number): Promise<Record<string, string>> {
     if (Protocol.lstAPYs) return Protocol.lstAPYs[chainId.toString()] || {};

--- a/packages/lending/src/protocol.type.ts
+++ b/packages/lending/src/protocol.type.ts
@@ -104,3 +104,17 @@ export interface RepayFields {
   borrower: string;
   balanceBps?: number;
 }
+
+type reserveTokens = {
+  asset: common.Token;
+  isSupplyEnabled: boolean;
+  isBorrowEnabled: boolean;
+  [key: string]: any;
+};
+
+export type ProtocolInfo = {
+  chainId: number;
+  protocolId: string;
+  marketId: string;
+  reserveTokens: reserveTokens[];
+};

--- a/packages/lending/src/protocol.type.ts
+++ b/packages/lending/src/protocol.type.ts
@@ -105,7 +105,7 @@ export interface RepayFields {
   balanceBps?: number;
 }
 
-type reserveTokens = {
+type reserveToken = {
   asset: common.Token;
   isSupplyEnabled: boolean;
   isBorrowEnabled: boolean;
@@ -116,5 +116,5 @@ export type ProtocolInfo = {
   chainId: number;
   protocolId: string;
   marketId: string;
-  reserveTokens: reserveTokens[];
+  reserveTokens: reserveToken[];
 };

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.test.ts
@@ -3,8 +3,22 @@ import { Portfolio } from 'src/protocol.portfolio';
 import * as common from '@protocolink/common';
 import { expect } from 'chai';
 import { filterPortfolio } from 'src/protocol.utils';
+import { supportedChainIds } from './configs';
 
 describe('Test Aave V2 LendingProtocol', function () {
+  context('Test getReserveTokens', function () {
+    supportedChainIds.forEach((chainId) => {
+      it(`network: ${common.toNetworkId(chainId)}`, async function () {
+        const protocol = await LendingProtocol.createProtocol(chainId);
+
+        const reserveTokens = await protocol.getReserveTokens();
+        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
+
+        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+      });
+    });
+  });
+
   context('Test getPortfolio', function () {
     const testCases = [
       {

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.test.ts
@@ -11,10 +11,12 @@ describe('Test Aave V2 LendingProtocol', function () {
       it(`network: ${common.toNetworkId(chainId)}`, async function () {
         const protocol = await LendingProtocol.createProtocol(chainId);
 
+        const reserveTokensFromCache = await protocol.getReserveTokensFromCache();
         const reserveTokens = await protocol.getReserveTokens();
-        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
 
-        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+        expect(reserveTokensFromCache).to.have.lengthOf.above(0);
+        expect(reserveTokens).to.have.lengthOf.above(0);
+        expect(reserveTokensFromCache).to.deep.equal(reserveTokens);
       });
     });
   });

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.ts
@@ -26,7 +26,7 @@ import { Protocol } from 'src/protocol';
 import { ProtocolDataProviderInterface } from './contracts/ProtocolDataProvider';
 import { RAY_DECIMALS, SECONDS_PER_YEAR, calculateCompoundedRate, normalize } from '@aave/math-utils';
 import * as apisdk from '@protocolink/api';
-import { calcBorrowGrossApy, calcSupplyGrossApy, getLstApyFromMap } from 'src/protocol.utils';
+import { calcBorrowGrossApy, calcSupplyGrossApy, fetchReservesData, getLstApyFromMap } from 'src/protocol.utils';
 import * as common from '@protocolink/common';
 import * as logics from '@protocolink/logics';
 
@@ -58,8 +58,13 @@ export class LendingProtocol extends Protocol {
   }
 
   async initializeReservesConfig() {
-    const service = new logics.aavev2.Service(this.chainId, this.provider);
-    const { reserveTokens } = await service.getReserveTokens();
+    let reserveTokens: ReserveTokens[] = [];
+
+    try {
+      reserveTokens = await this.getReserveTokens();
+    } catch {
+      reserveTokens = await this.getReserveTokensOnChain();
+    }
 
     const reserveMap: ReserveMap = {};
 
@@ -77,6 +82,17 @@ export class LendingProtocol extends Protocol {
 
     this.reserveTokens = reserveTokens;
     this.reserveMap = reserveMap;
+  }
+
+  async getReserveTokens() {
+    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
+    return reserveTokens;
+  }
+
+  async getReserveTokensOnChain() {
+    const service = new logics.aavev2.Service(this.chainId, this.provider);
+    const { reserveTokens } = await service.getReserveTokens();
+    return reserveTokens;
   }
 
   private _protocolDataProvider?: ProtocolDataProvider;

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.ts
@@ -402,6 +402,19 @@ export class LendingProtocol extends Protocol {
     return this.getPortfolios(account).then((portfolios) => portfolios[0]);
   }
 
+  async getProtocolInfos() {
+    const reserveTokens = await this.getReserveTokens();
+
+    return [
+      {
+        chainId: this.chainId,
+        protocolId: this.id,
+        marketId: this.market.id,
+        reserveTokens,
+      },
+    ];
+  }
+
   toUnderlyingToken(_marketId: string, protocolToken: common.Token) {
     return this.reserveMap[protocolToken.address].asset;
   }

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.ts
@@ -61,9 +61,9 @@ export class LendingProtocol extends Protocol {
     let reserveTokens: ReserveTokens[] = [];
 
     try {
-      reserveTokens = await this.getReserveTokens();
+      reserveTokens = await this.getReserveTokensFromCache();
     } catch {
-      reserveTokens = await this.getReserveTokensOnChain();
+      reserveTokens = await this.getReserveTokens();
     }
 
     const reserveMap: ReserveMap = {};
@@ -84,12 +84,12 @@ export class LendingProtocol extends Protocol {
     this.reserveMap = reserveMap;
   }
 
-  async getReserveTokens() {
+  async getReserveTokensFromCache() {
     const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
     return reserveTokens;
   }
 
-  async getReserveTokensOnChain() {
+  async getReserveTokens() {
     const service = new logics.aavev2.Service(this.chainId, this.provider);
     const { reserveTokens } = await service.getReserveTokens();
     return reserveTokens;

--- a/packages/lending/src/protocols/aave-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v2/lending-protocol.ts
@@ -84,9 +84,8 @@ export class LendingProtocol extends Protocol {
     this.reserveMap = reserveMap;
   }
 
-  async getReserveTokensFromCache() {
-    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
-    return reserveTokens;
+  async getReserveTokensFromCache(): Promise<ReserveTokens[]> {
+    return await fetchReservesData(this.id, this.chainId);
   }
 
   async getReserveTokens() {

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.test.ts
@@ -11,10 +11,12 @@ describe('Test Aave V3 LendingProtocol', function () {
       it(`network: ${common.toNetworkId(chainId)}`, async function () {
         const protocol = await LendingProtocol.createProtocol(chainId);
 
+        const reserveTokensFromCache = await protocol.getReserveTokensFromCache();
         const reserveTokens = await protocol.getReserveTokens();
-        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
 
-        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+        expect(reserveTokensFromCache).to.have.lengthOf.above(0);
+        expect(reserveTokens).to.have.lengthOf.above(0);
+        expect(reserveTokensFromCache).to.deep.equal(reserveTokens);
       });
     });
   });

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.test.ts
@@ -3,8 +3,22 @@ import { Portfolio } from 'src/protocol.portfolio';
 import * as common from '@protocolink/common';
 import { expect } from 'chai';
 import { filterPortfolio } from 'src/protocol.utils';
+import { supportedChainIds } from './configs';
 
 describe('Test Aave V3 LendingProtocol', function () {
+  context('Test getReserveTokens', function () {
+    supportedChainIds.forEach((chainId) => {
+      it(`network: ${common.toNetworkId(chainId)}`, async function () {
+        const protocol = await LendingProtocol.createProtocol(chainId);
+
+        const reserveTokens = await protocol.getReserveTokens();
+        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
+
+        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+      });
+    });
+  });
+
   context('Test getPortfolio', function () {
     const testCases = [
       {

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.ts
@@ -395,6 +395,19 @@ export class LendingProtocol extends Protocol {
     return this.getPortfolios(account).then((portfolios) => portfolios[0]);
   }
 
+  async getProtocolInfos() {
+    const reserveTokens = await this.getReserveTokens();
+
+    return [
+      {
+        chainId: this.chainId,
+        protocolId: this.id,
+        marketId: this.market.id,
+        reserveTokens,
+      },
+    ];
+  }
+
   override canLeverageByCollateral(_marketId: string, assetToken: common.Token) {
     return assetToken.symbol !== 'GHO';
   }

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.ts
@@ -83,9 +83,8 @@ export class LendingProtocol extends Protocol {
     this.hasNativeToken = hasNativeToken;
   }
 
-  async getReserveTokensFromCache() {
-    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
-    return reserveTokens;
+  async getReserveTokensFromCache(): Promise<ReserveTokens[]> {
+    return await fetchReservesData(this.id, this.chainId);
   }
 
   async getReserveTokens() {

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.ts
@@ -57,9 +57,9 @@ export class LendingProtocol extends Protocol {
     let reserveTokens: ReserveTokens[] = [];
 
     try {
-      reserveTokens = await this.getReserveTokens();
+      reserveTokens = await this.getReserveTokensFromCache();
     } catch {
-      reserveTokens = await this.getReserveTokensOnChain();
+      reserveTokens = await this.getReserveTokens();
     }
 
     const reserveMap: ReserveMap = {};
@@ -83,12 +83,12 @@ export class LendingProtocol extends Protocol {
     this.hasNativeToken = hasNativeToken;
   }
 
-  async getReserveTokens() {
+  async getReserveTokensFromCache() {
     const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
     return reserveTokens;
   }
 
-  async getReserveTokensOnChain() {
+  async getReserveTokens() {
     const service = new logics.aavev3.Service(this.chainId, this.provider);
     const { reserveTokens } = await service.getReserveTokens();
     return reserveTokens;

--- a/packages/lending/src/protocols/aave-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/aave-v3/lending-protocol.ts
@@ -24,7 +24,7 @@ import { Portfolio } from 'src/protocol.portfolio';
 import { Protocol } from 'src/protocol';
 import { RAY_DECIMALS, SECONDS_PER_YEAR, calculateCompoundedRate, normalize } from '@aave/math-utils';
 import * as apisdk from '@protocolink/api';
-import { calcBorrowGrossApy, calcSupplyGrossApy, getLstApyFromMap } from 'src/protocol.utils';
+import { calcBorrowGrossApy, calcSupplyGrossApy, fetchReservesData, getLstApyFromMap } from 'src/protocol.utils';
 import * as common from '@protocolink/common';
 import * as logics from '@protocolink/logics';
 
@@ -54,8 +54,13 @@ export class LendingProtocol extends Protocol {
   }
 
   async initializeReservesConfig() {
-    const service = new logics.aavev3.Service(this.chainId, this.provider);
-    const { reserveTokens } = await service.getReserveTokens();
+    let reserveTokens: ReserveTokens[] = [];
+
+    try {
+      reserveTokens = await this.getReserveTokens();
+    } catch {
+      reserveTokens = await this.getReserveTokensOnChain();
+    }
 
     const reserveMap: ReserveMap = {};
     let hasNativeToken = false;
@@ -76,6 +81,17 @@ export class LendingProtocol extends Protocol {
     this.reserveTokens = reserveTokens;
     this.reserveMap = reserveMap;
     this.hasNativeToken = hasNativeToken;
+  }
+
+  async getReserveTokens() {
+    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
+    return reserveTokens;
+  }
+
+  async getReserveTokensOnChain() {
+    const service = new logics.aavev3.Service(this.chainId, this.provider);
+    const { reserveTokens } = await service.getReserveTokens();
+    return reserveTokens;
   }
 
   private _poolDataProvider?: PoolDataProvider;

--- a/packages/lending/src/protocols/compound-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/compound-v3/lending-protocol.ts
@@ -365,6 +365,24 @@ export class LendingProtocol extends Protocol {
     return Promise.all(configMap[this.chainId].markets.map(({ id }) => this.getPortfolio(account, id)));
   }
 
+  async getProtocolInfo(marketId: string) {
+    const { baseToken, assets } = await this.getMarket(marketId);
+
+    return {
+      chainId: this.chainId,
+      protocolId: this.id,
+      marketId,
+      reserveTokens: [
+        { isSupplyEnabled: true, isBorrowEnabled: false, asset: baseToken },
+        ...assets.map(({ token }) => ({ isSupplyEnabled: false, isBorrowEnabled: true, asset: token })),
+      ],
+    };
+  }
+
+  async getProtocolInfos() {
+    return Promise.all(configMap[this.chainId].markets.map(({ id }) => this.getProtocolInfo(id)));
+  }
+
   newSupplyLogic({ marketId, input }: SupplyParams) {
     const { baseToken, comet } = getMarketConfig(this.chainId, marketId);
 

--- a/packages/lending/src/protocols/compound-v3/lending-protocol.ts
+++ b/packages/lending/src/protocols/compound-v3/lending-protocol.ts
@@ -373,8 +373,8 @@ export class LendingProtocol extends Protocol {
       protocolId: this.id,
       marketId,
       reserveTokens: [
-        { isSupplyEnabled: true, isBorrowEnabled: false, asset: baseToken },
-        ...assets.map(({ token }) => ({ isSupplyEnabled: false, isBorrowEnabled: true, asset: token })),
+        { isSupplyEnabled: true, isBorrowEnabled: true, asset: baseToken },
+        ...assets.map(({ token }) => ({ isSupplyEnabled: true, isBorrowEnabled: false, asset: token })),
       ],
     };
   }

--- a/packages/lending/src/protocols/morphoblue/lending-protocol.ts
+++ b/packages/lending/src/protocols/morphoblue/lending-protocol.ts
@@ -187,6 +187,24 @@ export class LendingProtocol extends Protocol {
     return Promise.all(configMap[this.chainId].markets.map(({ id }) => this.getPortfolio(account, id)));
   }
 
+  async getProtocolInfo(marketId: string) {
+    const { loanToken, collateralToken } = getMarket(this.chainId, marketId);
+
+    return {
+      chainId: this.chainId,
+      protocolId: this.id,
+      marketId,
+      reserveTokens: [
+        { isSupplyEnabled: true, isBorrowEnabled: false, asset: collateralToken },
+        { isSupplyEnabled: false, isBorrowEnabled: true, asset: loanToken },
+      ],
+    };
+  }
+
+  async getProtocolInfos() {
+    return Promise.all(configMap[this.chainId].markets.map(({ id }) => this.getProtocolInfo(id)));
+  }
+
   override canCollateralSwap() {
     return false;
   }

--- a/packages/lending/src/protocols/radiant-v2/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/radiant-v2/lending-protocol.test.ts
@@ -12,10 +12,12 @@ describe('Test Radiant V2 LendingProtocol', function () {
       it(`network: ${common.toNetworkId(chainId)}`, async function () {
         const protocol = await LendingProtocol.createProtocol(chainId);
 
+        const reserveTokensFromCache = await protocol.getReserveTokensFromCache();
         const reserveTokens = await protocol.getReserveTokens();
-        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
 
-        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+        expect(reserveTokensFromCache).to.have.lengthOf.above(0);
+        expect(reserveTokens).to.have.lengthOf.above(0);
+        expect(reserveTokensFromCache).to.deep.equal(reserveTokens);
       });
     });
   });

--- a/packages/lending/src/protocols/radiant-v2/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/radiant-v2/lending-protocol.test.ts
@@ -4,8 +4,22 @@ import * as common from '@protocolink/common';
 import { expect } from 'chai';
 import { filterPortfolio } from 'src/protocol.utils';
 import { mainnetTokens } from './tokens';
+import { supportedChainIds } from './configs';
 
 describe('Test Radiant V2 LendingProtocol', function () {
+  context('Test getReserveTokens', function () {
+    supportedChainIds.forEach((chainId) => {
+      it(`network: ${common.toNetworkId(chainId)}`, async function () {
+        const protocol = await LendingProtocol.createProtocol(chainId);
+
+        const reserveTokens = await protocol.getReserveTokens();
+        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
+
+        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+      });
+    });
+  });
+
   context('Test getPortfolio', function () {
     const testCases = [
       {

--- a/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
@@ -79,9 +79,8 @@ export class LendingProtocol extends Protocol {
     this.reserveMap = reserveMap;
   }
 
-  async getReserveTokensFromCache() {
-    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
-    return reserveTokens;
+  async getReserveTokensFromCache(): Promise<ReserveTokens[]> {
+    return await fetchReservesData(this.id, this.chainId);
   }
 
   async getReserveTokens() {

--- a/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
@@ -56,9 +56,9 @@ export class LendingProtocol extends Protocol {
     let reserveTokens: ReserveTokens[] = [];
 
     try {
-      reserveTokens = await this.getReserveTokens();
+      reserveTokens = await this.getReserveTokensFromCache();
     } catch {
-      reserveTokens = await this.getReserveTokensOnChain();
+      reserveTokens = await this.getReserveTokens();
     }
 
     const reserveMap: ReserveMap = {};
@@ -79,12 +79,12 @@ export class LendingProtocol extends Protocol {
     this.reserveMap = reserveMap;
   }
 
-  async getReserveTokens() {
+  async getReserveTokensFromCache() {
     const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
     return reserveTokens;
   }
 
-  async getReserveTokensOnChain() {
+  async getReserveTokens() {
     const service = new logics.radiantv2.Service(this.chainId, this.provider);
     const { reserveTokens } = await service.getReserveTokens();
     return reserveTokens;

--- a/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
+++ b/packages/lending/src/protocols/radiant-v2/lending-protocol.ts
@@ -353,6 +353,19 @@ export class LendingProtocol extends Protocol {
     return this.getPortfolios(account).then((portfolios) => portfolios[0]);
   }
 
+  async getProtocolInfos() {
+    const reserveTokens = await this.getReserveTokens();
+
+    return [
+      {
+        chainId: this.chainId,
+        protocolId: this.id,
+        marketId: this.market.id,
+        reserveTokens,
+      },
+    ];
+  }
+
   toUnderlyingToken(_marketId: string, protocolToken: common.Token) {
     return this.reserveMap[protocolToken.address].asset;
   }

--- a/packages/lending/src/protocols/spark/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.test.ts
@@ -3,8 +3,22 @@ import { Portfolio } from 'src/protocol.portfolio';
 import * as common from '@protocolink/common';
 import { expect } from 'chai';
 import { filterPortfolio } from 'src/protocol.utils';
+import { supportedChainIds } from './configs';
 
 describe('Test Spark LendingProtocol', function () {
+  context('Test getReserveTokens', function () {
+    supportedChainIds.forEach((chainId) => {
+      it(`network: ${common.toNetworkId(chainId)}`, async function () {
+        const protocol = await LendingProtocol.createProtocol(chainId);
+
+        const reserveTokens = await protocol.getReserveTokens();
+        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
+
+        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+      });
+    });
+  });
+
   context('Test getPortfolio', function () {
     const testCases = [
       {

--- a/packages/lending/src/protocols/spark/lending-protocol.test.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.test.ts
@@ -11,10 +11,12 @@ describe('Test Spark LendingProtocol', function () {
       it(`network: ${common.toNetworkId(chainId)}`, async function () {
         const protocol = await LendingProtocol.createProtocol(chainId);
 
+        const reserveTokensFromCache = await protocol.getReserveTokensFromCache();
         const reserveTokens = await protocol.getReserveTokens();
-        const reserveTokensOnChain = await protocol.getReserveTokensOnChain();
 
-        expect(JSON.stringify(reserveTokens)).to.eq(JSON.stringify(reserveTokensOnChain));
+        expect(reserveTokensFromCache).to.have.lengthOf.above(0);
+        expect(reserveTokens).to.have.lengthOf.above(0);
+        expect(reserveTokensFromCache).to.deep.equal(reserveTokens);
       });
     });
   });

--- a/packages/lending/src/protocols/spark/lending-protocol.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.ts
@@ -83,9 +83,8 @@ export class LendingProtocol extends Protocol {
     this.hasNativeToken = hasNativeToken;
   }
 
-  async getReserveTokensFromCache() {
-    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
-    return reserveTokens;
+  async getReserveTokensFromCache(): Promise<ReserveTokens[]> {
+    return await fetchReservesData(this.id, this.chainId);
   }
 
   async getReserveTokens() {

--- a/packages/lending/src/protocols/spark/lending-protocol.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.ts
@@ -57,9 +57,9 @@ export class LendingProtocol extends Protocol {
     let reserveTokens: ReserveTokens[] = [];
 
     try {
-      reserveTokens = await this.getReserveTokens();
+      reserveTokens = await this.getReserveTokensFromCache();
     } catch {
-      reserveTokens = await this.getReserveTokensOnChain();
+      reserveTokens = await this.getReserveTokens();
     }
 
     const reserveMap: ReserveMap = {};
@@ -83,12 +83,12 @@ export class LendingProtocol extends Protocol {
     this.hasNativeToken = hasNativeToken;
   }
 
-  async getReserveTokens() {
+  async getReserveTokensFromCache() {
     const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
     return reserveTokens;
   }
 
-  async getReserveTokensOnChain() {
+  async getReserveTokens() {
     const service = new logics.spark.Service(this.chainId, this.provider);
     const { reserveTokens } = await service.getReserveTokens();
     return reserveTokens;

--- a/packages/lending/src/protocols/spark/lending-protocol.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.ts
@@ -24,7 +24,7 @@ import { Portfolio } from 'src/protocol.portfolio';
 import { Protocol } from 'src/protocol';
 import { RAY_DECIMALS, SECONDS_PER_YEAR, calculateCompoundedRate, normalize } from '@aave/math-utils';
 import * as apisdk from '@protocolink/api';
-import { calcBorrowGrossApy, calcSupplyGrossApy, getLstApyFromMap } from 'src/protocol.utils';
+import { calcBorrowGrossApy, calcSupplyGrossApy, fetchReservesData, getLstApyFromMap } from 'src/protocol.utils';
 import * as common from '@protocolink/common';
 import * as logics from '@protocolink/logics';
 
@@ -54,8 +54,13 @@ export class LendingProtocol extends Protocol {
   }
 
   async initializeReservesConfig() {
-    const service = new logics.spark.Service(this.chainId, this.provider);
-    const { reserveTokens } = await service.getReserveTokens();
+    let reserveTokens: ReserveTokens[] = [];
+
+    try {
+      reserveTokens = await this.getReserveTokens();
+    } catch {
+      reserveTokens = await this.getReserveTokensOnChain();
+    }
 
     const reserveMap: ReserveMap = {};
     let hasNativeToken = false;
@@ -76,6 +81,17 @@ export class LendingProtocol extends Protocol {
     this.reserveTokens = reserveTokens;
     this.reserveMap = reserveMap;
     this.hasNativeToken = hasNativeToken;
+  }
+
+  async getReserveTokens() {
+    const reserveTokens: ReserveTokens[] = await fetchReservesData(this.id, this.chainId);
+    return reserveTokens;
+  }
+
+  async getReserveTokensOnChain() {
+    const service = new logics.spark.Service(this.chainId, this.provider);
+    const { reserveTokens } = await service.getReserveTokens();
+    return reserveTokens;
   }
 
   private _poolDataProvider?: PoolDataProvider;

--- a/packages/lending/src/protocols/spark/lending-protocol.ts
+++ b/packages/lending/src/protocols/spark/lending-protocol.ts
@@ -394,6 +394,19 @@ export class LendingProtocol extends Protocol {
     return this.getPortfolios(account).then((portfolios) => portfolios[0]);
   }
 
+  async getProtocolInfos() {
+    const reserveTokens = await this.getReserveTokens();
+
+    return [
+      {
+        chainId: this.chainId,
+        protocolId: this.id,
+        marketId: this.market.id,
+        reserveTokens,
+      },
+    ];
+  }
+
   toUnderlyingToken(_marketId: string, protocolToken: common.Token) {
     return this.reserveMap[protocolToken.address].asset;
   }


### PR DESCRIPTION
- [x] implement reserves data caching
- [x] implement getProtocolInfos for adapter
- [x] add test for getReserveTokens
- [x] yarn changeset

Using the S3 cache reduces the retrieval time to 200-250ms, which is approximately 5 times faster than fetching data directly from the blockchain.

```bash
Aave V2 LendingProtocol

getReserveTokens (S3 Cache): 200-230ms
reserveTokensOnChain: 1.3-2.0s


Aave V3 LendingProtocol

getReserveTokens (S3 Cache): 200-250ms
reserveTokensOnChain: 0.8-2.5s


Radiant V2 LendingProtocol

getReserveTokens (S3 Cache): 200-230ms
reserveTokensOnChain: 1.3-2.1s


Spark LendingProtocol

getReserveTokens (S3 Cache): 200-230ms
reserveTokensOnChain: 0.9-1.1s
```