### PR TITLE
ci: bump GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16
 


### PR DESCRIPTION
## Why
GitHub is deprecating the Node 20 action runtime. Runners will be forced to Node 24 from **2026-06-02**, and Node 20 is removed from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The current workflows trigger the deprecation warning.

## What
Bump action runtime versions only — no behavior change to the build:

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | @v3 | @v6 | node24 |
| `actions/setup-node` | @v3 | @v6 | node24 |

## Scope / non-goals
- **`node-version: 16` is intentionally unchanged.** The action *runtime* (Node running the action itself) is separate from the *project* Node used by `yarn install`/tests. This PR only fixes the deprecation warning; bumping the project Node is a separate effort.
- Verified the target majors run on Node 24 via each action's `action.yml` `runs.using`.

## Verify
- CI (lint / unit-test / e2e-test) green and consistent with before.