### PR TITLE
fix(common): decode symbol and name independently in getTokens

### DIFF
--- a/packages/common/src/web3-toolkit.test.ts
+++ b/packages/common/src/web3-toolkit.test.ts
@@ -57,10 +57,11 @@ describe('Web3Toolkit', function () {
           mainnetTokens.USDC.address,
           mainnetTokens.ETH.address,
           mainnetTokens.WETH.address,
+          mainnetTokens.MKR.address,
           ELASTIC_ADDRESS,
           mainnetTokens.DAI.address,
         ],
-        expected: [mainnetTokens.USDC, mainnetTokens.ETH, mainnetTokens.WETH, mainnetTokens.ETH, mainnetTokens.DAI],
+        expected: [mainnetTokens.USDC, mainnetTokens.ETH, mainnetTokens.WETH, mainnetTokens.MKR, mainnetTokens.ETH, mainnetTokens.DAI],
       },
       {
         chainId: ChainId.zksync,

--- a/packages/common/src/web3-toolkit.ts
+++ b/packages/common/src/web3-toolkit.ts
@@ -108,19 +108,23 @@ export class Web3Toolkit {
       } else {
         const [decimals] = this.erc20Iface.decodeFunctionResult('decimals', returnData[j]);
         j++;
+
         let symbol: string;
-        let name: string;
         try {
           [symbol] = this.erc20Iface.decodeFunctionResult('symbol', returnData[j]);
-          j++;
-          [name] = this.erc20Iface.decodeFunctionResult('name', returnData[j]);
-          j++;
         } catch {
           symbol = utils.parseBytes32String(returnData[j]);
-          j++;
-          name = utils.parseBytes32String(returnData[j]);
-          j++;
         }
+        j++;
+
+        let name: string;
+        try {
+          [name] = this.erc20Iface.decodeFunctionResult('name', returnData[j]);
+        } catch {
+          name = utils.parseBytes32String(returnData[j]);
+        }
+        j++;
+
         tokens.push(new Token(this.chainId, tokenAddress, decimals, symbol, name));
       }
     }


### PR DESCRIPTION
## Description
- Separate symbol and name decoding in \Web3Toolkit.getTokens\ into independent \	ry/catch\ blocks.
- Previously, a single \	ry/catch\ wrapped both symbol and name decoding. If \symbol\ decoding succeeded as string and incremented \j\, but \
ame\ decoding failed (e.g. \ytes32\ name like MKR), the \catch\ block executed with an already-incremented \j\, reading \eturnData[j]\ as symbol and corrupting array indices for all subsequent tokens.
- Aligns \getTokens\ decoding logic with \getToken\.

## Testing
- Extended \getTokens\ test suite in \packages/common/src/web3-toolkit.test.ts\ with \MKR\ bytes32 token test.